### PR TITLE
fix the incorrect lan and lat, and utm conversion (fix #7)

### DIFF
--- a/mtpy/utils/gis_tools.py
+++ b/mtpy/utils/gis_tools.py
@@ -334,7 +334,7 @@ def project_point_utm2ll(easting, northing, utm_zone, datum='WGS84', epsg=None):
             zone_number = int(utm_zone[0:-1])
             zone_letter = utm_zone[-1]
         except ValueError:
-            raise ValueError('Zone number {0} is not a number'.format(utm_zone[0:2]))
+            raise ValueError('Zone number {0} is not a number'.format(utm_zone[0:-1]))
         is_northern = 1 if zone_letter.lower() >= 'n' else 0
 
         utm_cs.SetUTM(zone_number, is_northern)
@@ -771,8 +771,15 @@ def transform_utm_to_ll(easting, northing, zone,
     utm_coordinate_system = osr.SpatialReference()
     # Set geographic coordinate system to handle lat/lon
     utm_coordinate_system.SetWellKnownGeogCS(reference_ellipsoid)
-    is_northern = northing > 0
-    utm_coordinate_system.SetUTM(zone, is_northern)
+
+    try:
+        zone_number = int(zone[0:-1])
+        zone_letter = zone[-1]
+    except ValueError:
+        raise ValueError('Zone number {0} is not a number'.format(zone[0:-1]))
+    is_northern = 1 if zone_letter.lower() >= 'n' else 0
+
+    utm_coordinate_system.SetUTM(zone_number, is_northern)
 
     # Clone ONLY the geographic coordinate system
     ll_coordinate_system = utm_coordinate_system.CloneGeogCS()

--- a/mtpy/utils/gis_tools.py
+++ b/mtpy/utils/gis_tools.py
@@ -326,7 +326,7 @@ def project_point_utm2ll(easting, northing, utm_zone, datum='WGS84', epsg=None):
             ogrerr = utm_cs.ImportFromEPSG(epsg)
             if ogrerr != OGRERR_NONE:
                 raise Exception("GDAL/osgeo ogr error code: {}".format(ogrerr))
-            # utm_zone = get_utm_string_from_sr(utm_cs)
+                # utm_zone = get_utm_string_from_sr(utm_cs)
     else:
         # assert len(utm_zone) == 3, 'UTM zone should be imput as ##N or ##S'
 
@@ -739,8 +739,6 @@ def epsg_project(x, y, epsg_from, epsg_to):
     return pyproj.transform(p1, p2, x, y)
 
 
-@deprecated("This function may be removed in later release. mtpy.utils.gis_tools.project_point_ll2utm() should be "
-            "used instead.")
 def utm_wgs84_conv(lat, lon):
     """
     Bidirectional UTM-WGS84 converter https://github.com/Turbo87/utm/blob/master/utm/conversion.py
@@ -766,6 +764,8 @@ def utm_wgs84_conv(lat, lon):
 
 
 @gdal_data_check
+@deprecated("This function may be removed in later release. mtpy.utils.gis_tools.project_point_utm2ll() should be "
+            "used instead.")
 def transform_utm_to_ll(easting, northing, zone,
                         reference_ellipsoid='WGS84'):
     utm_coordinate_system = osr.SpatialReference()
@@ -792,6 +792,8 @@ def transform_utm_to_ll(easting, northing, zone,
 
 
 @gdal_data_check
+@deprecated("This function may be removed in later release. mtpy.utils.gis_tools.project_point_ll2utm() should be "
+            "used instead.")
 def transform_ll_to_utm(lon, lat, reference_ellipsoid='WGS84'):
     """
     transform a (lon,lat) to  a UTM coordinate.

--- a/mtpy/utils/gis_tools.py
+++ b/mtpy/utils/gis_tools.py
@@ -194,12 +194,14 @@ def get_utm_zone(latitude, longitude):
     Get utm zone from a given latitude and longitude
     """
     zone_number = (int(1 + (longitude + 180.0) / 6.0))
-    if latitude < 0.0:
-        is_northern = 0
-        n_str = 'S'
-    else:
-        is_northern = 1
-        n_str = 'N'
+    n_str = _utm_letter_designator(latitude)
+    is_northern = 1 if latitude >= 0 else 0
+    # if latitude < 0.0:
+    #     is_northern = 0
+    #     n_str = 'S'
+    # else:
+    #     is_northern = 1
+    #     n_str = 'N'
 
     return zone_number, is_northern, '{0:02.0f}{1}'.format(zone_number, n_str)
 

--- a/mtpy/utils/gis_tools.py
+++ b/mtpy/utils/gis_tools.py
@@ -319,24 +319,23 @@ def project_point_utm2ll(easting, northing, utm_zone, datum='WGS84', epsg=None):
     utm_cs = osr.SpatialReference()
     utm_cs.SetWellKnownGeogCS(datum)
 
-    if (utm_zone is None) or (len(utm_zone) == 0) or (utm_zone == '0'):
+    if not utm_zone or (utm_zone == '0'):
         if epsg is None:
             raise ValueError('Please provide either utm_zone or epsg')
         else:
             ogrerr = utm_cs.ImportFromEPSG(epsg)
             if ogrerr != OGRERR_NONE:
                 raise Exception("GDAL/osgeo ogr error code: {}".format(ogrerr))
-            utm_zone = get_utm_string_from_sr(utm_cs)
+            # utm_zone = get_utm_string_from_sr(utm_cs)
     else:
-        assert len(utm_zone) == 3, 'UTM zone should be imput as ##N or ##S'
+        # assert len(utm_zone) == 3, 'UTM zone should be imput as ##N or ##S'
 
         try:
-            zone_number = int(utm_zone[0:2])
+            zone_number = int(utm_zone[0:-1])
+            zone_letter = utm_zone[-1]
         except ValueError:
             raise ValueError('Zone number {0} is not a number'.format(utm_zone[0:2]))
-        is_northern = 1
-        if 's' in utm_zone.lower():
-            is_northern = 0
+        is_northern = 1 if zone_letter.lower() >= 'n' else 0
 
         utm_cs.SetUTM(zone_number, is_northern)
 

--- a/tests/utils/test_gis_tools.py
+++ b/tests/utils/test_gis_tools.py
@@ -65,7 +65,7 @@ class TestGisTools(TestCase):
         self.assertTrue(np.isclose(northing, self.northing))
 
     def test_transform_utm_to_ll(self):
-        new_lon, new_lat, evel = transform_utm_to_ll(self.easting, self.northing, 55)
+        new_lon, new_lat, evel = transform_utm_to_ll(self.easting, self.northing, self.zone)
 
         print(new_lat, new_lon)
 

--- a/tests/utils/test_gis_tools.py
+++ b/tests/utils/test_gis_tools.py
@@ -15,7 +15,7 @@ class TestGisTools(TestCase):
         self.zone = '55H'
         self.easting = 702562.773
         self.northing = 6202448.526
-        self.atol = 0.1  # tolerance of error
+        self.atol = 0.3  # tolerance of error
 
     def test_ll_to_utm(self):
         zone, easting, northing = ll_to_utm(self.nref, self.lat, self.lon)


### PR DESCRIPTION
texted and fixed all 3 pairs of functions that transform between lat, lon and utm in gis_tools. see #7 for more information.