### PR TITLE
Aviod Travis-CI build timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,28 +32,28 @@ stages:
 jobs:
   include:
     - stage: prepare cache  # run saperate job to build dependencies to avoid 50 min timeout on travis
-      script: chmod -vR +x ./bin/* && . ./bin/travis-setup-env.sh
+      script: true # place holder, the before_Script will run anyway
       env:
         - MATPLOTLIB_VERSION=2.0.2 QT_VERSION=5
     - stage: prepare cache
-      script: chmod -vR +x ./bin/* && . ./bin/travis-setup-env.sh
+      script: true
       env:
         - MATPLOTLIB_VERSION=2.1.0 QT_VERSION=5
     - stage: prepare cache
-      script: chmod -vR +x ./bin/* && . ./bin/travis-setup-env.sh
+      script: true
       env:
         - MATPLOTLIB_VERSION=2.0.2 QT_VERSION=4
     - stage: prepare cache
-      script: chmod -vR +x ./bin/* && . ./bin/travis-setup-env.sh
+      script: true
       env:
         - MATPLOTLIB_VERSION=1.5.3 QT_VERSION=5
 #    - stage: test
 #    - stage: deploy
 
 before_script:
-  - if [ -z ${CACHED+x} ]; then chmod -vR +x ./bin/* && . ./bin/travis-setup-env.sh; fi
+  - chmod -vR +x ./bin/* && . ./bin/travis-setup-env.sh  
 
-script: 
+script: # testing stages, will run only in testing stages
   - py.test -v -n 4 --dist=loadscope --cov=mtpy --cov-report= tests/analysis
   - py.test -v -n 4 --dist=loadscope --cov=mtpy --cov-report= tests/core
   - MTPY_TEST_COMPARE_IMAGE=False py.test -v -n 4 --dist=loadscope --cov=mtpy --cov-report= tests/imaging


### PR DESCRIPTION
The Travis-CI.org has a 50 minutes job timeout. However building the complete dependences from source takes about 30 minutes and the tests takes about 30 minutes too. as the result, if there is not cached built dependencies (when a new branch is added, or testing environment variable changes) all jobs will timeout after 50 minutes resulting an error in the build.

current solution is to utilize the bate feature on travis that prepares cache that contains the built dependencies in the first build stage then run the testing stages, each of the stage will be in different jobs of 50 minutes limits, and effectively avoid the timeout problem.
