### PR TITLE
Change plot pen depth 2D to take periods

### DIFF
--- a/examples/scripts/plot_penetration_depth2d.py
+++ b/examples/scripts/plot_penetration_depth2d.py
@@ -1,10 +1,7 @@
 #! /usr/bin/env python
 """
 Description:
-    Example python script
-    plot 3D penetration depth for a folder of EDI files
-
-    input = path2edifolder
+    Plot 2D penetration depth for a folder of EDI files.
 
 CreationDate:   23/03/2018
 Developer:      fei.zhang@ga.gov.au
@@ -12,52 +9,30 @@ Developer:      fei.zhang@ga.gov.au
 Revision History:
     LastUpdate:     23/03/2018   FZ
 
+    brenainn.moushall@ga.gov.au 03-04-2020 15:39:33 AEDT:
+        - Add selection of periods by specifying periods in seconds
+        - Clean up script
 """
-
-import os
-import sys
-import tempfile
 from mtpy.imaging import penetration_depth2d as pen2d
-import matplotlib.pyplot as plt
 
+edidir = '/path/to/edi/files'
 
-try:
-    # PACK_ROOT = os.environ['PACK_ROOT']
-    # mtpy_path = os.path.join(PACK_ROOT, 'mtpy')
-    mtpy_path = os.environ['MTPY_ROOT']
-except:
-    print("Warn: The environment variable MTPY_ROOT is not defined. We will guess")
-    mtpy_path = os.path.abspath('../..')
+# selected_periods: the periods in seconds to plot depth for across each
+# station.
+selected_periods = [10., 100., 500., 600.]
+# ptol: tolerance to use when finding nearest period to each selected
+# period. If abs(selected period - nearest period) is greater than
+# selected period * ptol, then the period is discarded and will appear
+# as a gap in the plot.
+ptol = 0.20
+# zcomponent: component to plot. Valid parameters are 'det, 'zxy' and
+# 'zyx'
+zcomponent = 'det'  # 'zxy', 'zyx' also options
 
-if not os.path.isdir(mtpy_path):
-    raise Exception("the guessed mtpy dir %s is not a folder!"% mtpy_path)
-
-# change the variable below according to your edi files folder !!!
-# edidir = r'C:/mtpywin/mtpy/data/edifiles'  # / is Unix and Win-Dos compatible
-# or get this variable from the cmdline:  edidir = sys.argv[1]
-
-edidir = os.path.join(mtpy_path,'data','edifiles2')
-
-# savepath = r'C:\tmp'
-temp_dir = tempfile.gettempdir()
-print('Using temporary directory ' + temp_dir)
-savepath = temp_dir
-
-
-if not os.path.isdir(edidir):
-    print ("Error: please provide the path to edi folder")
-    sys.exit(1)
-
-period_index_list = [0, 1, 10, 20, 30, 40, 50, 59]  # user to customise
-
-# show three different kind of calculated pen-depth
-pen2d.plot2Dprofile(edidir, period_index_list, 'det')
-
-pen2d.plot2Dprofile(edidir, period_index_list, 'zxy')
-
-pen2d.plot2Dprofile(edidir, period_index_list, 'zyx')
-
-
-plt.savefig(os.path.join(savepath,'penetration_depth_profile.png'), # change to your preffered filename
-            dpi=400) # change to your preferred file resolution
+pen2d.plot2Dprofile(edi_dir=edidir,
+                    selected_periods=selected_periods,
+                    ptol=ptol,
+                    zcomponent='det',
+                    save=True,
+                    savepath='/tmp/Depth2D.png')
 

--- a/mtpy/imaging/penetration.py
+++ b/mtpy/imaging/penetration.py
@@ -1,14 +1,19 @@
 """
-    Description:
-        This file defines imaging functions for penetration.
-        The plotting function are extracted and implemented in plot() of each class from penetration_depth1D.py,
-        penetration_depth2D.py and penetration_depth3D.py
+Description:
+    This file defines imaging functions for penetration.
+    The plotting function are extracted and implemented in plot() of each class from penetration_depth1D.py,
+    penetration_depth2D.py and penetration_depth3D.py
 
-    Usage:
-        see descriptions of each clases
+Usage:
+    see descriptions of each clases
 
-    Author: YingzhiGou
-    Date: 20/06/2017
+Author: YingzhiGou
+Date: 20/06/2017
+
+Revision History:
+    brenainn.moushall@ga.gov.au 03-04-2020 15:40:53 AEDT:
+        - Modify Depth2D and get_penetration_depth to get nearest
+          period to specified periods
 """
 
 import os
@@ -39,6 +44,7 @@ class Depth1D(ImagingBase):
         Description:
         For a given input MT object, plot the Penetration Depth vs all the periods (1/freq).
     """
+
     def set_data(self, data):
         # this plot only use one edi each time
         self._set_edi(data)
@@ -87,7 +93,7 @@ class Depth1D(ImagingBase):
         if 'zxy' in self._rholist:
             # One of the 4-components: XY
             penetration_depth = scale_param * \
-                                np.sqrt(zeta.resistivity[:, 0, 1] * periods)
+                np.sqrt(zeta.resistivity[:, 0, 1] * periods)
 
             # pen_zxy, = plt.semilogx(periods, -penetration_depth, '-*',label='Zxy')
             pen_zxy, = plt.loglog(
@@ -99,7 +105,7 @@ class Depth1D(ImagingBase):
 
         if 'zyx' in self._rholist:
             penetration_depth = scale_param * \
-                                np.sqrt(zeta.resistivity[:, 1, 0] * periods)
+                np.sqrt(zeta.resistivity[:, 1, 0] * periods)
 
             pen_zyx, = plt.loglog(
                 periods, penetration_depth, color='g', marker='o', label='Zyx')
@@ -115,42 +121,48 @@ class Depth1D(ImagingBase):
                 periods, det_penetration_depth, color='b', marker='^', label='Determinant')
             legendh.append(pen_det)
 
-        plt.legend(
-            handles=legendh,
-            bbox_to_anchor=(
-                0.1,
-                0.5),
-            loc=3,
-            ncol=1,
-            borderaxespad=0.)
+            plt.legend(
+                handles=legendh,
+                bbox_to_anchor=(
+                    0.1,
+                    0.5),
+                loc=3,
+                ncol=1,
+                borderaxespad=0.)
 
-        title = "Penetration Depth for file %s" % self._data.fn
-        plt.title(title)
-        plt.xlabel("Log Period (seconds)", fontsize=16)
-        plt.ylabel("Penetration Depth (meters)", fontsize=16)
-        plt.gca().invert_yaxis()
-        # set window title
-        self._fig.canvas.set_window_title(title)
+            title = "Penetration Depth for file %s" % self._data.fn
+            plt.title(title)
+            plt.xlabel("Log Period (seconds)", fontsize=16)
+            plt.ylabel("Penetration Depth (meters)", fontsize=16)
+            plt.gca().invert_yaxis()
+            # set window title
+            self._fig.canvas.set_window_title(title)
 
 
 class Depth2D(ImagingBase):
     """
-    With a list of MT object and a list of period index,
-    generate a profile using occam2d module,
-    then plot the Penetration Depth profile at the given periods vs the stations locations.
+    With a list of MT object and a list of period selected periods,
+    generate a profile using occam2d module, then plot the penetration
+    depth profile at the given periods vs stations.
     """
+    def __init__(self, selected_periods, data=None, ptol=0.05, rho='det'):
+        super(Depth2D, self).__init__()
+        self._selected_periods = selected_periods
+        self._ptol = ptol
+        self._rho = None
+        self.set_data(data)
+        self.set_rho(rho)
+
     def plot(self, tick_params={}, **kwargs):
         if self._rho is None:
             raise ZComponentError
-        elif self._period_indexes is None or not self._period_indexes:
-            raise Exception("please provide a period index list")
         elif self._fig is not None:
             return  # nothing to plot
 
         pr = occam2d.Profile(edi_list=self._data)
         pr.generate_profile()
         # pr.plot_profile(station_id=[0, 4])
-        
+
         if 'fontsize' in list(kwargs.keys()):
             fontsize = kwargs['fontsize']
         else:
@@ -158,27 +170,26 @@ class Depth2D(ImagingBase):
 
         self._fig = plt.figure(figsize=(8, 6), dpi=80)
         self._fig.set_tight_layout(True)
-        for period_index in self._period_indexes:
-            self._logger.debug("doing period index %s", period_index)
-            (stations, periods, pen, _) = get_penetration_depth(pr.edi_list, int(period_index), whichrho=self._rho)
-            line_label = "Period=%.2e s" % periods[0]
+        for selected_period in self._selected_periods:
+            (stations, periods, pen, _) = get_penetration_depth(pr.edi_list, selected_period, self._ptol, whichrho=self._rho)
+            line_label = "Period=%.2e s" % selected_period
 
             plt.plot(
                 pr.station_locations,
                 pen,
                 "--",
-#                marker="o",
-#                markersize=12,
-#                linewidth=2,
+                #                marker="o",
+                #                markersize=12,
+                #                linewidth=2,
                 label=line_label,
                 **kwargs)
             plt.legend()
 
         plt.ylabel(
             'Penetration Depth (Metres) Computed by %s' %
-            self._rho, 
+            self._rho,
             fontsize=fontsize
-            )
+        )
         plt.yticks(fontsize=fontsize)
 
         plt.xlabel('MT Penetration Depth Profile Over Stations.', fontsize=fontsize)
@@ -188,18 +199,20 @@ class Depth2D(ImagingBase):
             plt.xticks(
                 pr.station_locations,
                 pr.station_list,
-                fontsize=fontsize,
+                fontsize=fontsize / 2,
+                rotation=45,
                 **tick_params
-#                rotation='horizontal',
-                )
+                #                rotation='horizontal',
+            )
         else:  # Are the stations in the same order as the profile generated pr.station_list????
             plt.xticks(
                 pr.station_locations,
                 stations,
-                fontsize=fontsize,
+                fontsize=fontsize / 2,
+                rotation=45,
                 **tick_params
-#                rotation='horizontal',
-                )
+                #                rotation='horizontal',
+            )
 
         # plt.tight_layout()
         plt.gca().xaxis.tick_top()
@@ -210,14 +223,7 @@ class Depth2D(ImagingBase):
         # this plot require multiple edi files
         self._set_edis(data)
 
-    def __init__(self, data=None, period_index_list=None, rho='det'):
-        super(Depth2D, self).__init__()
-        self._period_indexes = None
-        self._rho = None
-        self.set_data(data)
-        self.set_rho(rho)
-        self.set_period_index_list(period_index_list)
-
+    
     def set_rho(self, rho):
         if rho is None or rho in DEFAULT_RHOLIST:
             self._rho = rho
@@ -225,12 +231,6 @@ class Depth2D(ImagingBase):
         else:
             self._logger.critical("unsupported method to compute penetratoin depth: %s", rho)
             # raise Exception("unsupported method to compute penetratoin depth: %s" % rho)
-
-    def set_period_index_list(self, period_index_list):
-        if period_index_list:
-            self._period_indexes = period_index_list
-        else:
-            self._logger.error("Please provide a period index list like [1,2,3,4]")
 
 
 class Depth3D(ImagingBase):
@@ -241,6 +241,7 @@ class Depth3D(ImagingBase):
     Note that the values of periods within tolerance (ptol=0.1) are considered as equal.
     Setting a smaller value for ptol may result less MT sites data included.
     """
+
     def __init__(self, edis=None, period=None, rho='det', ptol=0.1):
         super(Depth3D, self).__init__()
         self._rho = None
@@ -248,7 +249,7 @@ class Depth3D(ImagingBase):
         self._period_fmt = None
         self._ptol = ptol
         self.set_data(edis)
-        #self._set_edis(edis)
+        # self._set_edis(edis)
         self.set_rho(rho)
         self.set_period(period)
 
@@ -292,13 +293,13 @@ class Depth3D(ImagingBase):
 
             print("***  Plot pendepth3D using the first value from the period list above ***")
 
-            self._period=periods[0]
+            self._period = periods[0]
             self.plot(period_by_index=False)
             #raise ImagingError("MT Periods values are NOT equal! In such case a float value must be selected from the period list")
         else:
             # good normal case
             period0 = periods[0]
-            print(("plotting for period %s" %period0))
+            print(("plotting for period %s" % period0))
 
             if period0 < 1.0:
                 # kept 4 signifiant digits - nonzero digits
@@ -494,15 +495,24 @@ class Depth3D(ImagingBase):
 
 # Utility functions (may need to move to utility module
 
-def get_penetration_depth(mt_obj_list, per_index, whichrho='det'):
+def get_penetration_depth(mt_obj_list, selected_period, ptol, whichrho='det'):
     """
-    compute the penetration depth of mt_obj at the given period_index, and using whichrho option
-    :param per_index: the index of periods 0, 1, ...
-    :param mt_obj_list: list of edi file paths or mt objects
-    :param whichrho: det, zxy, or zyx
-    :return:
-    """
+    Compute the penetration depth of mt_obj at the given period_index, and using whichrho option.
 
+    Parameters
+    ----------
+    mt_obj_list : list of MT
+        List of stations as MT objects.
+    selected_period : float
+        The period in seconds to plot depth for.
+    ptol : float
+        Tolerance to use when finding nearest period to selected period.
+        If abs(selected_period - nearest_period) is greater than
+        ptol * selected_period, then the period is discarded and will
+        appear as a gap in the plot.
+    whichrho : str
+        'det', 'zxy' or 'zyx'. The component to plot.
+    """
     scale_param = np.sqrt(1.0 / (2.0 * np.pi * 4 * np.pi * 10 ** (-7)))
 
     # per_index=0,1,2,....
@@ -510,6 +520,7 @@ def get_penetration_depth(mt_obj_list, per_index, whichrho='det'):
     pen_depth = []
     stations = []
     latlons = []
+    _logger.info("Plotting nearest period to {} for all stations".format(selected_period))
     for mt_obj in mt_obj_list:
         if isinstance(mt_obj, str) and os.path.isfile(mt_obj):
             mt_obj = mt.MT(mt_obj)
@@ -521,23 +532,23 @@ def get_penetration_depth(mt_obj_list, per_index, whichrho='det'):
         latlons.append((mt_obj.lat, mt_obj.lon))
         # the attribute Z
         zeta = mt_obj.Z
+        per_index = np.argmin(np.fabs(zeta.freq - selected_period))
+        per = zeta.freq[per_index]
+        if abs(selected_period - per) > selected_period * ptol:
+            periods.append(np.nan)
+            pen_depth.append(np.nan)
+            _logger.warning("Nearest preiod {} on station {} was beyond tolerance of {} and "
+                            "discarded".format(per, mt_obj.Site.id, ptol))
+            continue
 
-        if per_index >= len(zeta.freq):
-            _logger.debug(
-                "Number of frequecies (Max per_index)= %s", len(
-                    zeta.freq))
-            raise Exception(
-                "Index out_of_range Error: period index must be less than number of periods in zeta.freq")
-
-        per = 1.0 / zeta.freq[per_index]
         periods.append(per)
 
         if whichrho == 'zxy':
             penetration_depth = - scale_param * \
-                                np.sqrt(zeta.resistivity[per_index, 0, 1] * per)
+                np.sqrt(zeta.resistivity[per_index, 0, 1] * per)
         elif whichrho == 'zyx':
             penetration_depth = - scale_param * \
-                                np.sqrt(zeta.resistivity[per_index, 1, 0] * per)
+                np.sqrt(zeta.resistivity[per_index, 1, 0] * per)
         elif whichrho == 'det':  # the 2X2 complex Z-matrix's determinant abs value
             # determinant value at the given period index
             det2 = np.abs(zeta.det[per_index])
@@ -554,11 +565,11 @@ def get_penetration_depth(mt_obj_list, per_index, whichrho='det'):
     return stations, periods, pen_depth, latlons
 
 
-def load_edi_files(edi_path,file_list = None):
+def load_edi_files(edi_path, file_list=None):
 
     if file_list is None:
         file_list = [ff for ff in os.listdir(edi_path) if ff.endswith("edi")]
-        
+
     if edi_path is not None:
         edi_list = [mt.MT(os.path.join(edi_path, edi)) for edi in file_list]
     return edi_list

--- a/mtpy/imaging/penetration_depth2d.py
+++ b/mtpy/imaging/penetration_depth2d.py
@@ -10,6 +10,11 @@ Usage:
 
 Author: fei.zhang@ga.gov.au
 Date:   2017-01-23
+
+Revision History:
+    brenainn.moushall@ga.gov.au 03-04-2020 15:41:39 AEDT:
+        - Modify 2D plot profile to take a list of selected periods
+          instead of period indicies
 """
 
 import glob
@@ -41,27 +46,22 @@ _logger = MtPyLog.get_mtpy_logger(__name__)
 
 
 # use the Zcompotent=[det, zxy, zyx]
-def plot2Dprofile(edi_dir, period_index_list=None, zcomponent='det', 
-                  edi_list=None, tick_params={}, save=False,savepath=None,**kwargs):
-    #edi_dir = "/Softlab/Githubz/mtpy2/tests/data/edifiles/"
-    # edi_dir="E:/Githubz/mtpy2/tests/data/edifiles/"
-    # edi_dir=r"E:\Githubz\mtpy2\examples\data/edi2"
-
-    # 1 get a list of edi files, which are suppose to be in a profile.
+def plot2Dprofile(edi_dir, selected_periods, ptol=0.05, zcomponent='det',
+                  edi_list=None, tick_params={}, save=False, savepath=None, **kwargs):
     edifiles = glob.glob(os.path.join(edi_dir, '*.edi'))
 
     _logger.debug("edi files: %s", edifiles)
 
     edis = load_edi_files(edi_dir, file_list=edi_list)
-    plot = Depth2D(edis, period_index_list, zcomponent)
+    plot = Depth2D(selected_periods, edis, ptol, zcomponent)
     plot.plot(tick_params, **kwargs)
     if save:
         if os.path.isdir(savepath):
-            savepath == os.path.join(savepath,'Depth2D.png')
+            savepath == os.path.join(savepath, 'Depth2D.png')
         if savepath is not None:
             plot._fig.savefig(savepath)
         else:
-            savepath = os.path.join(edi_dir,'Depth2D.png')
+            savepath = os.path.join(edi_dir, 'Depth2D.png')
     plot.show()
 
 
@@ -140,6 +140,7 @@ def barplot_multi_station_penentration_depth(
     # Check that the periods are the same value for all stations
     return (stations, depths, periods)
 
+
 # =============================================================================================
 # Example Usage:
 # python mtpy/imaging/penetration_depth2d.py examples/data/edi_files/ 1 10 20 30
@@ -150,7 +151,7 @@ if __name__ == "__main__old":
 
     if len(sys.argv) < 2:
         print(("Usage: %s edi_dir" % sys.argv[0]))
-        print ("python examples/penetration_depth2d.py tests/data/edifiles/ 0 1 10 20 30 40 50 59")
+        print("python examples/penetration_depth2d.py tests/data/edifiles/ 0 1 10 20 30 40 50 59")
         sys.exit(1)
     elif os.path.isdir(sys.argv[1]):
         edi_dir = sys.argv[1]  # the first argument is path2_edi_dir
@@ -172,14 +173,15 @@ if __name__ == "__main__old":
 # =============================================================================================
 
 @click.command()
-@click.option('-i','--input',type=str,default='examples/data/edi_files',help='directory or edsi data files')
-@click.option('-p','--period_list',type=str,default="0 1 10 20 30 40",help='Periods seperated by space')
-def plot_penetration_image(input,period_list):
+@click.option('-i', '--input', type=str, default='examples/data/edi_files', help='directory or edsi data files')
+@click.option('-p', '--period_list', type=str, default="0 1 10 20 30 40", help='Periods seperated by space')
+def plot_penetration_image(input, period_list):
     if os.path.isdir(input):
         period_index_list = period_list.split(' ')
         plot2Dprofile(input, period_index_list, zcomponent='det')
     else:
         print("Please provide an edi directory !")
+
 
 if __name__ == '__main__':
     plot_penetration_image()


### PR DESCRIPTION
Specifying period indicies would cause an exception if the period
index did not exist on all stations. It also causes issue because
the period for each index may not be the same across all stations.

The new approach is to specify a list of periods in seconds and a
tolerance. The nearest periods to the provided periods will be plotted.
If the nearest found period is outside of tolerance, then it will be
discarded and appear as a gap in the plot for that station.